### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Demo showing [TimescaleDB](timescale.com) in Phoenix.
   * Install docker and docker-compose
   * `docker-compose up -d`
   * `mix deps.get`
-  * `mix ecto.create && mix.ecto.migrate`
+  * `mix ecto.create && mix ecto.migrate`
   * `cd assets && npm install && cd -`
   * `mix phx.server`
   * `open http://localhost:4000`


### PR DESCRIPTION
Fix a typo in the command to run ecto migrations